### PR TITLE
[deploy] Initial workflow for the ED318 converter and publish to github pages

### DIFF
--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -2,8 +2,6 @@ name: Publish ED-318
 
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: '30 4 * * *'
 
 env:
     ED269_URL: https://data.geo.admin.ch/ch.bazl.einschraenkungen-drohnen/einschraenkungen-drohnen/einschraenkungen-drohnen_4326.json


### PR DESCRIPTION
This PR adds performs the conversion to ED-318 and publishes the result to github pages.

Tested here: https://orbitalize.github.io/geoawareness-cis-sandbox/