### PR TITLE
Update geospatial-utils lib to v0.3.0

### DIFF
--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -11,7 +11,7 @@ env:
     ED269_FILENAME: ed269_source.json
     ED318_FILENAME: ed318.json
     ED318_SKYGUIDE_FILENAME: skyguide_ed318.json
-    GEOSPATIAL_UTILS_VERSION: v0.2.0
+    GEOSPATIAL_UTILS_VERSION: v0.3.0
 
 permissions:
   contents: read


### PR DESCRIPTION
I could not run the CI from this branch to test it as the configuration prevents that from being done.
However I could run it locally and:
- the ed219.json files are exactly the same
- the ed318.json files have the following diff:

```diff
*** orig.json   2026-07-08 13:57:23.020883404 +0200
--- converted.json      2026-07-08 13:57:05.637693639 +0200
***************
*** 1263943,1263949 ****
          "text": "FOCA"
        }
      ],
!     "validFrom": "2026-07-08T06:07:49.479244+00:00"
    },
    "type": "FeatureCollection"
  }
--- 1263943,1263949 ----
          "text": "FOCA"
        }
      ],
!     "validFrom": "2026-07-08T10:20:50.388316+00:00"
    },
    "type": "FeatureCollection"
  }

```